### PR TITLE
Pr/chapter view/anchor

### DIFF
--- a/src/common/ChapterView/index.tsx
+++ b/src/common/ChapterView/index.tsx
@@ -35,7 +35,11 @@ const ChapterView = ({ chapterLink }: Props) => {
 
   return (
     <div id={chapter.link} className="chapter">
-      <h2>{chapter.title}</h2>
+      <h2>
+        <a href={`#${chapter.link}`} className="chapter__title-anchor">
+          {chapter.title}
+        </a>
+      </h2>
       <p className="chapter__lead">
         {chapter.content.type === 'broken'
           ? 'Chyba ve formátu kapitoly'

--- a/src/common/ChapterView/styles.scss
+++ b/src/common/ChapterView/styles.scss
@@ -1,6 +1,27 @@
 .chapter {
   scroll-margin-top: 2rem;
 
+  &__title-anchor {
+    color: inherit;
+    text-decoration: none;
+    position: relative;
+
+    &::before {
+      position: absolute;
+      right: 100%;
+      opacity: 0.2;
+      visibility: hidden;
+      content: '#';
+    }
+    
+    &:hover,
+    &:focus {
+      &::before {
+        visibility: inherit;
+      }
+    }
+  }
+
   &__lead {
     max-width: 20rem;
   }

--- a/src/common/ChapterView/styles.scss
+++ b/src/common/ChapterView/styles.scss
@@ -1,4 +1,6 @@
 .chapter {
+  scroll-margin-top: 2rem;
+
   &__lead {
     max-width: 20rem;
   }


### PR DESCRIPTION
## Přidán scroll-margin, aby nadpis nebyl tak nalepený na horní hranu viewportu.

### Před

![image](https://user-images.githubusercontent.com/1045362/158712163-c7642a06-a724-4d5a-809f-829fa034dd24.png)

### Po

![image](https://user-images.githubusercontent.com/1045362/158712248-2540ea46-638b-49e7-a010-653b6b3b9114.png)

## Nově klikatelné nadpisy kapitol, aby se dal získat odkaz na kotvu i jednodušeji než proklikem z drobečkovky v lekci.

![image](https://user-images.githubusercontent.com/1045362/158712485-7417235f-f4dc-443e-8c1b-5729d2a4826d.png)


