### PR TITLE
Pr/figure

### DIFF
--- a/src/common/Figure/index.tsx
+++ b/src/common/Figure/index.tsx
@@ -10,7 +10,7 @@ const Figure = ({ src, alt, size }: Props) => {
   return (
     <div className="figure">
       <img
-        style={{ width: `${size ?? 100}%` }}
+        style={size ? { width: `${size}%` } : undefined}
         src={src}
         alt={alt}
       />

--- a/src/common/Figure/styles.scss
+++ b/src/common/Figure/styles.scss
@@ -4,7 +4,7 @@
   padding: 2rem 0;
 
   img {
-    width: 100%;
+    max-width: 100%;
     height: auto;
-  }  
+  }
 }

--- a/src/common/JsmlContainer/components.ts
+++ b/src/common/JsmlContainer/components.ts
@@ -28,7 +28,7 @@ export const baseJsmlComponents: JsmlComponents = {
       Figure,
       {
         src: String(attrs.src),
-        size: Number(attrs.size ?? 100),
+        size: Number(attrs.size),
         alt: String(attrs.alt),
       },
     );


### PR DESCRIPTION
Obrázky měly dříve povinně řečenou šířku v procentech rodiče nebo `100%`. To vedlo k tomu, že šířku musely mít i obrázky, které by se klidně mohly zobrazit ve svém přirozeném rozlišení, ale vynucením procent se zbytečně rozmazávaly a ještě byly na mobilech menší, než bylo potřeba.

## Před (rozmazané, až moc malé)

`::fig[token]{src=assets/token.png size=60}`

![](https://user-images.githubusercontent.com/1045362/158714000-2871f37a-9ed5-4e5c-9f86-bce534f86dc1.png)

![](https://user-images.githubusercontent.com/1045362/158714228-08d1f568-5ff2-4721-92dd-c75fd909754c.png)

## Po (ostré, co největší jde)

`::fig[token]{src=assets/token.png}`

![](https://user-images.githubusercontent.com/1045362/158714102-e363b1de-a3d6-4732-b0c5-59259a475717.png)

![](https://user-images.githubusercontent.com/1045362/158714265-f2303ba9-225b-4e02-a145-016c6d0d3649.png)


