### PR TITLE
Term: fix hover over invisible area

### DIFF
--- a/src/common/Term/styles.scss
+++ b/src/common/Term/styles.scss
@@ -20,17 +20,19 @@
   &__tooltip {
     position: absolute;
     bottom: 120%;
-    
+
     padding: 0.5rem 1rem;
     border-radius: 6px;
 
     background-color: black;
     color: #fff;
     text-align: center;
-    
+
     opacity: 0;
+    visibility: hidden;
     z-index: 1;
-    transition: 400ms;
+    transition-property: opacity, visibility;
+    transition-duration: 400ms;
 
     &::after {
       content: " ";
@@ -46,7 +48,7 @@
 
   &:hover &__tooltip {
     opacity: 1;
-    transition: 400ms;
+    visibility: inherit;
   }
 }
 


### PR DESCRIPTION
Oprava, aby tooltip nevyjížděl při přejetí myši mimo term.

### Předtím

![before](https://user-images.githubusercontent.com/1045362/161452684-1a807fb0-abe9-4fbe-a0b1-630488628e32.gif)

### Nyní

![after](https://user-images.githubusercontent.com/1045362/161452678-fd9484cf-3d37-47c0-8d20-e6ee07811be0.gif)
 