### PR TITLE
Use native dark scheme scrollbars to match dark code

### DIFF
--- a/src/common/ArticleContent/styles.scss
+++ b/src/common/ArticleContent/styles.scss
@@ -64,6 +64,7 @@ $code-emph-color: #e3e3e3;
       margin-top: 1.5rem;
       margin-bottom: 1.5rem;
       overflow-x: auto;
+      color-scheme: dark;
 
       code {
         background-color: transparent;


### PR DESCRIPTION
## Před:

![image](https://user-images.githubusercontent.com/1045362/217367449-348979dc-7aa7-41c8-b4ca-ff2d21524ac0.png)

![image](https://user-images.githubusercontent.com/1045362/217367486-dad0150b-e411-4751-8003-735ada74fca6.png)

## Po:

![image](https://user-images.githubusercontent.com/1045362/217367372-38371f8b-d304-4e4b-819d-ea2346f32f41.png)

![image](https://user-images.githubusercontent.com/1045362/217367407-0adeea9f-bf54-47e6-bcab-5f4fa314ceee.png)
