### PR TITLE
feat: Authorize access to /api endpoints with claims – WIP

### DIFF
--- a/src/server/api/admin.ts
+++ b/src/server/api/admin.ts
@@ -4,23 +4,6 @@ import { GroupModel, UserModel } from '../db';
 export const adminController = (config: any): Router => {
   const admin = express.Router();
 
-  admin.use(async (req, res, next) => {
-    if (req.auth?.scp === 'app') {
-      res.status(403);
-      res.send();
-      return;
-    }
-
-    const login: string | undefined = req.auth?.usr;
-    if (!config.admins.includes(login ?? '')) {
-      res.status(403);
-      res.send();
-      return;
-    }
-
-    next();
-  });
-
   admin.get('/groups', async (req, res) => {
     const groups = await GroupModel.find();
     res.json(

--- a/src/server/api/api.ts
+++ b/src/server/api/api.ts
@@ -2,10 +2,12 @@ import cors from 'cors';
 import express, { Router } from 'express';
 import { UserModel } from '../db';
 import { adminController } from './admin';
+import { auth } from './auth';
 
 export const apiController = (config: any): Router => {
   const api = express.Router();
   api.use(cors());
+  api.use(auth(config));
 
   api.use('/admin', adminController(config));
 

--- a/src/server/api/auth.ts
+++ b/src/server/api/auth.ts
@@ -1,0 +1,49 @@
+import express, { Router } from 'express';
+import { AccessCheck, AccessClaimCheck } from 'kodim-cms/esm/content/access-check.js';
+import { getAccount } from '../db';
+
+export const auth = (config: any): Router => {
+  const router = express.Router();
+
+  router.use(async (req, res, next) => {
+    const originalPath: string = req.path;
+    const method = req.method.toLowerCase();
+    const authorisationPath = `/api/${method}${originalPath}`;
+
+    //TODO: for applications, get claims from auth token
+    if (originalPath.startsWith('/admin') && req.auth?.scp === 'app') {
+      res.status(403);
+      res.send();
+      return;
+    }
+
+    //TODO: create Admins group instead of config.admins
+    const login: string | undefined = req.auth?.usr;
+    if (originalPath.startsWith('/admin') && !config.admins.includes(login ?? '')) {
+      res.status(403);
+      res.send();
+      return;
+    }
+
+    const account = await getAccount(login ?? null);
+
+   //TODO User --> GeneralUser
+    let claimCheck: AccessCheck = AccessClaimCheck.create(account.user, ...account.claims.content);
+
+    authorisationPath.split('/').slice(1).forEach((pathPart) => {
+      //TODO simple Entry
+      claimCheck = claimCheck.step({link: pathPart});
+    });
+
+    const accessAllowed = claimCheck.accepts();
+    if (!accessAllowed) {
+      res.status(403);
+      res.send();
+      return;
+    }
+
+    next();
+  });
+
+  return router;
+};


### PR DESCRIPTION
Umožňuje řídit přístup k API endpointům (`/api`) na základě claimů (aktuálně se berou ze skupin, později se mohou pro aplikace brát z tokenu). Claim bude ve tvaru `/api/<METHOD>/zbytek-URL`, tj. bude možné řídit zvlášť přístup k jednotlivým HTTP metodám.