### PR TITLE
feat: Styling for blockquote element.

### DIFF
--- a/src/common/ArticleContent/styles.scss
+++ b/src/common/ArticleContent/styles.scss
@@ -90,6 +90,37 @@ $code-emph-color: #e3e3e3;
       padding: 0rem 0.5rem;
     }
 
+    blockquote {
+      background-color: #555;
+      color: white;
+      padding-top: 1.5rem;
+      padding-bottom: 1.5rem;
+      margin-top: 1.5rem;
+      margin-bottom: 1.5rem;
+      overflow-x: auto;
+      color-scheme: dark;
+      position: relative;
+
+      &::before, &::after {
+        font-size: 6rem;
+        color: $color-palette-5;
+        opacity: 0.5;
+        position: absolute;
+      }
+
+      &::before {
+        content: '„';
+        bottom: 2.5rem;
+        left: 0;
+      }
+
+      &::after {
+        content: '“';
+        right: 0;
+        top: 2rem;
+      }
+    }
+
     li {
       margin-left: 2rem;
     }


### PR DESCRIPTION
Nastylování `blockquote` elementu, aby bylo možné vstupní texty uvádět jako text (který se zalomí) a ne jako kód, který se nezalomí. Např. zde: https://kodim.cz/kurzy/daweb/js1/dom-innerhtml/cv-manipulace#cvlekce%3Ekviz