### PR TITLE
Oprava formátování <blockquote>

### DIFF
--- a/website/src/app/components/ArticleContent/styles.module.scss
+++ b/website/src/app/components/ArticleContent/styles.module.scss
@@ -38,7 +38,7 @@
     margin-top: 1.5rem;
     margin-bottom: 1.5rem;
     max-width: 100%;
-    overflow-x: auto;
+    overflow: auto hidden;
     color-scheme: dark;
 
     code {
@@ -71,7 +71,7 @@
     padding: 1.5rem 4rem;
     margin-top: 1.5rem;
     margin-bottom: 1.5rem;
-    overflow-x: auto;
+    overflow: auto hidden;
     color-scheme: dark;
     position: relative;
 
@@ -85,14 +85,14 @@
 
     &::before {
       content: "„";
-      bottom: 2.8rem;
+      bottom: -0.2em;
       left: 0;
     }
 
     &::after {
       content: "“";
       right: 0;
-      top: 2rem;
+      top: -0.6ex;
     }
   }
 


### PR DESCRIPTION
Aby se u citací nezobrazoval posuvník.
Citace je použita např. zde: https://kodim.cz/czechitas/daweb/js1/uvod-do-js/cv-programy-promenne/prevod-meny